### PR TITLE
Added a task to validate the read group string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.2 - 2024-04-23
+- Added a task to validate the read group string, readGroupCheck
+- Made readGroups a workflow-level input
 # 1.0.1 - 2023-11-01
 - add "-M" in the command
 # 1.0.0 - 2023-06-14

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Parameter|Value|Description
 ---|---|---
 `fastqR1`|File|Fastq file for read 1
 `outputFileNamePrefix`|String|Prefix for output files
+`readGroups`|String|The readgroup information to be injected into the bam header
 `reference`|String|The genome reference build. For example: hg19, hg38, mm10
-`runBwamem2.readGroups`|String|The readgroup information to be injected into the bam header
 
 
 #### Optional workflow parameters:
@@ -49,6 +49,8 @@ Parameter|Value|Default|Description
 #### Optional task parameters:
 Parameter|Value|Default|Description
 ---|---|---|---
+`readGroupCheck.jobMemory`|Int|1|Memory allocated for this job
+`readGroupCheck.timeout`|Int|1|Hours before task timeout
 `countChunkSize.modules`|String|"python/3.7"|Required environment modules
 `countChunkSize.jobMemory`|Int|16|Memory allocated for this job
 `countChunkSize.timeout`|Int|48|Hours before task timeout
@@ -103,7 +105,28 @@ Output | Type | Description
  This section lists command(s) run by bwamem2 workflow
  
  
+ Validate the read group string prior to running the rest of the workflow
+ 
+ ```
+         set -euo pipefail 
+ 
+         # Split the string into an array 
+         IFS=$'\\t' read -ra readFields <<< ~{readGroups}
+         idPresent=false
+ 
+         for field in "${readFields[@]}"; do 
+             if [[ $field == ID:* ]]; then idPresent=true; break; fi
+         done 
+ 
+         # Confirm if string begins with '@RG' and 'ID' field is present
+         if ! [[ ~{readGroups} == @RG* ]] ; then 
+             echo "The read group line is not started with @RG" >&2; exit 1
+         fi
+         if ! $idPresent ; then echo "Missing ID within the read group line" >&2; exit 1 ; fi
+ ```
+ 
  Split the fastq files into chunks to parallelize the alignment (optional).  If requested, subsequent steps will be run on each fastq chunk
+ 
  ```
  
          if [ -z "~{numReads}" ]; then

--- a/commands.txt
+++ b/commands.txt
@@ -2,7 +2,28 @@
 This section lists command(s) run by bwamem2 workflow
 
 
+Validate the read group string prior to running the rest of the workflow
+
+```
+        set -euo pipefail 
+
+        # Split the string into an array 
+        IFS=$'\\t' read -ra readFields <<< ~{readGroups}
+        idPresent=false
+
+        for field in "${readFields[@]}"; do 
+            if [[ $field == ID:* ]]; then idPresent=true; break; fi
+        done 
+
+        # Confirm if string begins with '@RG' and 'ID' field is present
+        if ! [[ ~{readGroups} == @RG* ]] ; then 
+            echo "The read group line is not started with @RG" >&2; exit 1
+        fi
+        if ! $idPresent ; then echo "Missing ID within the read group line" >&2; exit 1 ; fi
+```
+
 Split the fastq files into chunks to parallelize the alignment (optional).  If requested, subsequent steps will be run on each fastq chunk
+
 ```
 
         if [ -z "~{numReads}" ]; then

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -58,12 +58,14 @@
             "bwamem2.numChunk": null,
             "bwamem2.numReads": null,
             "bwamem2.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",
+            "bwamem2.readGroupCheck.jobMemory": null,
+            "bwamem2.readGroupCheck.timeout": null,
             "bwamem2.reference": "hg19",
             "bwamem2.runBwamem2.addParam": null,
             "bwamem2.runBwamem2.bwaRef": null,
             "bwamem2.runBwamem2.jobMemory": null,
             "bwamem2.runBwamem2.modules": null,
-            "bwamem2.runBwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
+            "bwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwamem2.runBwamem2.threads": null,
             "bwamem2.runBwamem2.timeout": null,
             "bwamem2.slicerR1.jobMemory": null,
@@ -117,7 +119,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.1/output_metrics/PCSI0022C_notrim_nosplit_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.2/output_metrics/PCSI0022C_notrim_nosplit_bam.metrics",
                 "type": "script"
             }
         ]
@@ -181,12 +183,14 @@
             "bwamem2.numChunk": null,
             "bwamem2.numReads": null,
             "bwamem2.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",
+            "bwamem2.readGroupCheck.jobMemory": null,
+            "bwamem2.readGroupCheck.timeout": null,
             "bwamem2.reference": "hg19",
             "bwamem2.runBwamem2.addParam": null,
             "bwamem2.runBwamem2.bwaRef": null,
             "bwamem2.runBwamem2.jobMemory": null,
             "bwamem2.runBwamem2.modules": null,
-            "bwamem2.runBwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
+            "bwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwamem2.runBwamem2.threads": null,
             "bwamem2.runBwamem2.timeout": null,
             "bwamem2.slicerR1.jobMemory": null,
@@ -240,7 +244,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.1/output_metrics/PCSI0022C_trim_nosplit_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.2/output_metrics/PCSI0022C_trim_nosplit_bam.metrics",
                 "type": "script"
             }
         ]
@@ -304,12 +308,14 @@
             "bwamem2.numChunk": 4,
             "bwamem2.numReads": null,
             "bwamem2.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",
+            "bwamem2.readGroupCheck.jobMemory": null,
+            "bwamem2.readGroupCheck.timeout": null,
             "bwamem2.reference": "hg19",
             "bwamem2.runBwamem2.addParam": null,
             "bwamem2.runBwamem2.bwaRef": null,
             "bwamem2.runBwamem2.jobMemory": null,
             "bwamem2.runBwamem2.modules": null,
-            "bwamem2.runBwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
+            "bwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwamem2.runBwamem2.threads": null,
             "bwamem2.runBwamem2.timeout": null,
             "bwamem2.slicerR1.jobMemory": null,
@@ -363,7 +369,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.1/output_metrics/PCSI0022C_trim_split_hg19_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.2/output_metrics/PCSI0022C_trim_split_hg19_bam.metrics",
                 "type": "script"
             }
         ]
@@ -427,12 +433,14 @@
             "bwamem2.numChunk": 4,
             "bwamem2.numReads": null,
             "bwamem2.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001", 
+            "bwamem2.readGroupCheck.jobMemory": null,
+            "bwamem2.readGroupCheck.timeout": null,
             "bwamem2.reference": "hg19",
             "bwamem2.runBwamem2.addParam": null,
             "bwamem2.runBwamem2.bwaRef": null,
             "bwamem2.runBwamem2.jobMemory": null,
             "bwamem2.runBwamem2.modules": null,
-            "bwamem2.runBwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
+            "bwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwamem2.runBwamem2.threads": null,
             "bwamem2.runBwamem2.timeout": null,
             "bwamem2.slicerR1.jobMemory": null,
@@ -486,7 +494,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.1/output_metrics/PCSI0022C_notrim_split_hg19_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.2/output_metrics/PCSI0022C_notrim_split_hg19_bam.metrics",
                 "type": "script"
             }
         ]
@@ -550,12 +558,14 @@
             "bwamem2.numChunk": 4,
             "bwamem2.numReads": null,
             "bwamem2.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",      
+            "bwamem2.readGroupCheck.jobMemory": null,
+            "bwamem2.readGroupCheck.timeout": null,
             "bwamem2.reference": "hg38",
             "bwamem2.runBwamem2.addParam": null,
             "bwamem2.runBwamem2.bwaRef": null,
             "bwamem2.runBwamem2.jobMemory": null,
             "bwamem2.runBwamem2.modules": null,
-            "bwamem2.runBwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
+            "bwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwamem2.runBwamem2.threads": null,
             "bwamem2.runBwamem2.timeout": null,
             "bwamem2.slicerR1.jobMemory": null,
@@ -609,7 +619,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.1/output_metrics/PCSI0022C_trim_split_hg38_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.2/output_metrics/PCSI0022C_trim_split_hg38_bam.metrics",
                 "type": "script"
             }
         ]
@@ -662,12 +672,14 @@
             "bwamem2.numChunk": 4,
             "bwamem2.numReads": null,
             "bwamem2.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",     
+            "bwamem2.readGroupCheck.jobMemory": null,
+            "bwamem2.readGroupCheck.timeout": null,
             "bwamem2.reference": "hg19",
             "bwamem2.runBwamem2.addParam": null,
             "bwamem2.runBwamem2.bwaRef": null,
             "bwamem2.runBwamem2.jobMemory": null,
             "bwamem2.runBwamem2.modules": null,
-            "bwamem2.runBwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
+            "bwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwamem2.runBwamem2.threads": null,
             "bwamem2.runBwamem2.timeout": null,
             "bwamem2.slicerR1.jobMemory": null,
@@ -721,7 +733,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.1/output_metrics/PCSI0022C_trim_split_hg19_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.2/output_metrics/PCSI0022C_trim_split_hg19_bam_se.metrics",
                 "type": "script"
             }
         ]
@@ -774,12 +786,14 @@
             "bwamem2.numChunk": null,
             "bwamem2.numReads": null,
             "bwamem2.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",
+            "bwamem2.readGroupCheck.jobMemory": null,
+            "bwamem2.readGroupCheck.timeout": null,
             "bwamem2.reference": "hg19",
             "bwamem2.runBwamem2.addParam": null,
             "bwamem2.runBwamem2.bwaRef": null,
             "bwamem2.runBwamem2.jobMemory": null,
             "bwamem2.runBwamem2.modules": null,
-            "bwamem2.runBwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
+            "bwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwamem2.runBwamem2.threads": null,
             "bwamem2.runBwamem2.timeout": null,
             "bwamem2.slicerR1.jobMemory": null,
@@ -833,7 +847,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.1/output_metrics/PCSI0022C_trim_nosplit_hg19_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.2/output_metrics/PCSI0022C_trim_nosplit_hg19_bam_se.metrics",
                 "type": "script"
             }
         ]
@@ -886,12 +900,14 @@
             "bwamem2.numChunk": null,
             "bwamem2.numReads": null,
             "bwamem2.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",   
+            "bwamem2.readGroupCheck.jobMemory": null,
+            "bwamem2.readGroupCheck.timeout": null,
             "bwamem2.reference": "hg19",
             "bwamem2.runBwamem2.addParam": null,
             "bwamem2.runBwamem2.bwaRef": null,
             "bwamem2.runBwamem2.jobMemory": null,
             "bwamem2.runBwamem2.modules": null,
-            "bwamem2.runBwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
+            "bwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwamem2.runBwamem2.threads": null,
             "bwamem2.runBwamem2.timeout": null,
             "bwamem2.slicerR1.jobMemory": null,
@@ -945,7 +961,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.1/output_metrics/PCSI0022C_notrim_nosplit_hg19_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.2/output_metrics/PCSI0022C_notrim_nosplit_hg19_bam_se.metrics",
                 "type": "script"
             }
         ]
@@ -1009,12 +1025,14 @@
             "bwamem2.numChunk": 4,
             "bwamem2.numReads": null,
             "bwamem2.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",      
+            "bwamem2.readGroupCheck.jobMemory": null,
+            "bwamem2.readGroupCheck.timeout": null,
             "bwamem2.reference": "hg19",
             "bwamem2.runBwamem2.addParam": null,
             "bwamem2.runBwamem2.bwaRef": null,
             "bwamem2.runBwamem2.jobMemory": null,
             "bwamem2.runBwamem2.modules": null,
-            "bwamem2.runBwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
+            "bwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwamem2.runBwamem2.threads": null,
             "bwamem2.runBwamem2.timeout": null,
             "bwamem2.slicerR1.jobMemory": null,
@@ -1068,7 +1086,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.1/output_metrics/PCSI0022C_umi_adapter_trim_split_hg19_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.2/output_metrics/PCSI0022C_umi_adapter_trim_split_hg19_bam.metrics",
                 "type": "script"
             }
         ]
@@ -1132,12 +1150,14 @@
             "bwamem2.numChunk": 4,
             "bwamem2.numReads": 3713,
             "bwamem2.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",      
+            "bwamem2.readGroupCheck.jobMemory": null,
+            "bwamem2.readGroupCheck.timeout": null,
             "bwamem2.reference": "hg38",
             "bwamem2.runBwamem2.addParam": null,
             "bwamem2.runBwamem2.bwaRef": null,
             "bwamem2.runBwamem2.jobMemory": null,
             "bwamem2.runBwamem2.modules": null,
-            "bwamem2.runBwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
+            "bwamem2.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwamem2.runBwamem2.threads": null,
             "bwamem2.runBwamem2.timeout": null,
             "bwamem2.slicerR1.jobMemory": null,
@@ -1191,7 +1211,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.1/output_metrics/PCSI0022C_trim_split_hg38_numRead_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.2/output_metrics/PCSI0022C_trim_split_hg38_numRead_bam.metrics",
                 "type": "script"
             }
         ]
@@ -1255,12 +1275,14 @@
             "bwamem2.numChunk": null,
             "bwamem2.numReads": null,
             "bwamem2.outputFileNamePrefix": "neat_5x_EX_hg19_golden",
+            "bwamem2.readGroupCheck.jobMemory": null,
+            "bwamem2.readGroupCheck.timeout": null,
             "bwamem2.reference": "hg19",
             "bwamem2.runBwamem2.addParam": null,
             "bwamem2.runBwamem2.bwaRef": null,
             "bwamem2.runBwamem2.jobMemory": null,
             "bwamem2.runBwamem2.modules": null,
-            "bwamem2.runBwamem2.readGroups": "'@RG\\tID:1\\tLB:neat_5x_EX_hg19_golden\\tPL:illumina\\tPU:run_barcode\\tSM:neat_5x_EX_hg19_golden'",
+            "bwamem2.readGroups": "'@RG\\tID:1\\tLB:neat_5x_EX_hg19_golden\\tPL:illumina\\tPU:run_barcode\\tSM:neat_5x_EX_hg19_golden'",
             "bwamem2.runBwamem2.threads": null,
             "bwamem2.runBwamem2.timeout": null,
             "bwamem2.slicerR1.jobMemory": null,
@@ -1314,7 +1336,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.1/output_metrics/neat_5x_umi_extract_nosplit_hg19_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem2/1.0.2/output_metrics/neat_5x_umi_extract_nosplit_hg19_bam.metrics",
                 "type": "script"
             }
         ]


### PR DESCRIPTION
Added a task, readGroupCheck, which ensures that the read group string is in the correct format for bwa mem2 and converted readGroups into a workflow-level input. 

Made the same changes as for bwaMem, because it behaves in the same manner when given incorrect read group string.